### PR TITLE
Fix XML parsing for sites with only one entry

### DIFF
--- a/src/utils/parser.js
+++ b/src/utils/parser.js
@@ -85,7 +85,7 @@ export const parseRSS = (xmldata) => {
     item = []
   } = channel
 
-  const entries = item.map(nomalizeRssItem)
+  const entries = isArray(item) ? item.map(nomalizeRssItem) : [nomalizeAtomItem(item)]
 
   return {
     title,


### PR DESCRIPTION
My friend's site using XML feed and only have one entry.  When I try to fetch the feed it returns

```
Trace: TypeError: item.map is not a function
    at parseRSS (file:///home/neizod/feed-reader/src/utils/parser.js:88:24)
    at read (file:///home/neizod/feed-reader/src/main.js:34:27)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async extractFromUrl (file:///home/neizod/feed-reader/eval.js:10:17)
    at extractFromUrl (file:///home/neizod/feed-reader/eval.js:14:13)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

As I investigate, the `item` variable, after parsed from XML into JSON, can be an array or an object (like the case of Atom in the same file).  Thus, `.map` function fail to work on when it is actually an object.

This PR should fix the issue.